### PR TITLE
Allow cache to be restored for `inexact` match

### DIFF
--- a/pack/post-restore-steps.yml
+++ b/pack/post-restore-steps.yml
@@ -1,4 +1,4 @@
 steps:
 - script: cd $(CACHE_PACK_TOOLS_DIR) && node tools.js post-restore
-  condition: and(eq(variables.CACHE_PACK, 'true'), eq(variables.CACHE_RESTORED, 'true'))
+  condition: and(eq(variables.CACHE_PACK, 'true'), or(eq(variables.CACHE_RESTORED, 'true'), eq(variables.CACHE_RESTORED, 'inexact')))
   displayName: 'Cache pack: post-restore'

--- a/pack/tools.js
+++ b/pack/tools.js
@@ -152,7 +152,8 @@ function handlePreRestore() {
 function handlePostRestore() {
     checkVariables(['CACHE_PATH', 'CACHE_PATH_ORIGINAL']);
 
-    const cacheRestored = process.env.CACHE_RESTORED == 'true';
+    const cacheRestored = process.env.CACHE_RESTORED == 'true'
+                       || process.env.CACHE_RESTORED == 'inexact';
 
     if (!cacheRestored) {    
         console.log('Cache was not restored. Not attempting to unpack.');


### PR DESCRIPTION
I am using the new-ish `restoreKeys` feature for the `CacheBeta` task which seems to set `CACHE_RESTORED` to `inexact` when one of the cache keys from the `restoreKeys` list is used. This causes the condition in `post-restore-steps.yml` to fail: 

```
Evaluating: and(eq(variables['CACHE_PACK'], 'true'), eq(variables['CACHE_RESTORED'], 'true'))
Expanded: and(eq('true', 'true'), eq('inexact', 'true'))
Result: False
```

Since the cache is actually restored, this means it just doesn't get unpacked. This PR changes the condition in `post-restore-steps.yml` and the one `tools.js` so that either `true` or `inexact` is accepted.